### PR TITLE
Add -cfg command line parameter for custom configuration path

### DIFF
--- a/main.go
+++ b/main.go
@@ -15,13 +15,20 @@ func main() {
 	var showProfileMenu bool
 	var listProfilesNames bool
 	var showVersion bool
+	var configPath string
 
 	flag.StringVar(&profileName, "profile", "", "Apply a specific profile")
 	flag.BoolVar(&showProfileMenu, "profiles", false, "Show profile selection menu")
 	flag.BoolVar(&listProfilesNames, "list-profiles", false, "List available profile names")
 	flag.BoolVar(&showVersion, "version", false, "Show version information")
 	flag.BoolVar(&showVersion, "v", false, "Show version information (short)")
+	flag.StringVar(&configPath, "cfg", "", "Path to store/read configuration files (default: ~/.config/hyprmon)")
 	flag.Parse()
+
+	// Set custom config path if provided
+	if configPath != "" {
+		customConfigPath = configPath
+	}
 
 	// Handle version flag
 	if showVersion {

--- a/profiles.go
+++ b/profiles.go
@@ -13,6 +13,9 @@ import (
 	"golang.org/x/term"
 )
 
+// customConfigPath holds the custom configuration path set via -cfg flag
+var customConfigPath string
+
 type Profile struct {
 	Name      string    `json:"name"`
 	Monitors  []Monitor `json:"monitors"`
@@ -21,6 +24,12 @@ type Profile struct {
 }
 
 func getProfilesDir() string {
+	// Use custom config path if provided via -cfg flag
+	if customConfigPath != "" {
+		return filepath.Join(customConfigPath, "profiles")
+	}
+	
+	// Otherwise use default path
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return ""


### PR DESCRIPTION
Add a new -cfg flag that allows users to specify a custom directory for storing configuration files. When provided, profiles will be stored in <path>/profiles/ instead of the default ~/.config/hyprmon/profiles/. This enables users to maintain different sets of profiles or store configurations in alternative locations.