### PR TITLE
feat: add monitor mirroring support and upgrade to Go 1.25.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ on:
     branches: [main]
 
 env:
-  GO_VERSION: "1.24"
+  GO_VERSION: "1.25.1"
 
 jobs:
   test:

--- a/.github/workflows/pr-checks.yml
+++ b/.github/workflows/pr-checks.yml
@@ -5,7 +5,7 @@ on:
     types: [opened, synchronize, reopened]
 
 env:
-  GO_VERSION: "1.24"
+  GO_VERSION: "1.25.1"
 
 jobs:
   test:

--- a/.github/workflows/release-tagged.yml
+++ b/.github/workflows/release-tagged.yml
@@ -8,7 +8,7 @@ on:
     branches: [main]
 
 env:
-  GO_VERSION: "1.24"
+  GO_VERSION: "1.25.1"
   BINARY_NAME: hyprmon
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ on:
         type: string
 
 env:
-  GO_VERSION: "1.24"
+  GO_VERSION: "1.25.1"
   BINARY_NAME: hyprmon
 
 jobs:

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module hyprmon
 
-go 1.24.6
+go 1.25.1
 
 require (
+	github.com/charmbracelet/bubbles v0.21.0
 	github.com/charmbracelet/bubbletea v1.3.10
 	github.com/charmbracelet/lipgloss v1.1.0
 	golang.org/x/term v0.35.0
@@ -11,7 +12,6 @@ require (
 require (
 	github.com/atotto/clipboard v0.1.4 // indirect
 	github.com/aymanbagabas/go-osc52/v2 v2.0.1 // indirect
-	github.com/charmbracelet/bubbles v0.21.0 // indirect
 	github.com/charmbracelet/colorprofile v0.2.3-0.20250311203215-f60798e515dc // indirect
 	github.com/charmbracelet/x/ansi v0.10.1 // indirect
 	github.com/charmbracelet/x/cellbuf v0.0.13-0.20250311204145-2c3ea96c31dd // indirect

--- a/mirror_picker.go
+++ b/mirror_picker.go
@@ -1,0 +1,233 @@
+package main
+
+import (
+	"fmt"
+	"strings"
+
+	tea "github.com/charmbracelet/bubbletea"
+	"github.com/charmbracelet/lipgloss"
+)
+
+// wouldCreateCircularMirror checks if setting currentMonitor to mirror sourceMonitor
+// would create a circular mirroring chain
+func wouldCreateCircularMirror(currentMonitor, sourceMonitor string, allMonitors []Monitor) bool {
+	// Build a map of current mirror relationships
+	mirrorMap := make(map[string]string)
+	for _, mon := range allMonitors {
+		if mon.IsMirrored && mon.MirrorSource != "" {
+			mirrorMap[mon.Name] = mon.MirrorSource
+		}
+	}
+
+	// Check if sourceMonitor is already mirroring currentMonitor (direct or indirect)
+	visited := make(map[string]bool)
+	current := sourceMonitor
+
+	for {
+		if visited[current] {
+			// We've seen this monitor before - there's already a cycle
+			return true
+		}
+		visited[current] = true
+
+		// If the current monitor would mirror our target monitor, that's a cycle
+		if current == currentMonitor {
+			return true
+		}
+
+		// Follow the chain: what does the current monitor mirror?
+		next, exists := mirrorMap[current]
+		if !exists {
+			// This monitor doesn't mirror anything, no cycle
+			break
+		}
+		current = next
+	}
+
+	return false
+}
+
+// validateMirrorConfiguration checks for various mirror configuration issues
+func validateMirrorConfiguration(monitors []Monitor) []string {
+	var warnings []string
+
+	// Check for resolution mismatches
+	for _, mon := range monitors {
+		if mon.IsMirrored && mon.MirrorSource != "" {
+			for _, source := range monitors {
+				if source.Name == mon.MirrorSource {
+					if mon.PxW != source.PxW || mon.PxH != source.PxH {
+						warnings = append(warnings, fmt.Sprintf(
+							"Resolution mismatch: %s (%dx%d) mirroring %s (%dx%d)",
+							mon.Name, mon.PxW, mon.PxH,
+							source.Name, source.PxW, source.PxH))
+					}
+					break
+				}
+			}
+		}
+	}
+
+	// Check for disabled source monitors
+	for _, mon := range monitors {
+		if mon.IsMirrored && mon.MirrorSource != "" {
+			for _, source := range monitors {
+				if source.Name == mon.MirrorSource && !source.Active {
+					warnings = append(warnings, fmt.Sprintf(
+						"Mirror source %s is disabled but %s is trying to mirror it",
+						source.Name, mon.Name))
+					break
+				}
+			}
+		}
+	}
+
+	return warnings
+}
+
+type mirrorPickerModel struct {
+	availableMonitors []string // List of monitors that can be mirrored
+	selected          int      // Currently selected monitor index
+	currentMonitor    string   // Monitor being configured
+	currentSource     string   // Current mirror source (empty if not mirrored)
+}
+
+func newMirrorPicker(currentMonitor string, currentSource string, allMonitors []Monitor) mirrorPickerModel {
+	var availableMonitors []string
+
+	// Add "None" option to disable mirroring
+	availableMonitors = append(availableMonitors, "None")
+
+	// Add all other active monitors as potential sources
+	for _, mon := range allMonitors {
+		if mon.Name != currentMonitor && mon.Active && !mon.IsMirrored {
+			// Additional validation: prevent circular mirroring
+			if !wouldCreateCircularMirror(currentMonitor, mon.Name, allMonitors) {
+				availableMonitors = append(availableMonitors, mon.Name)
+			}
+		}
+	}
+
+	// Find current selection
+	selected := 0 // Default to "None"
+	if currentSource != "" {
+		for i, name := range availableMonitors {
+			if name == currentSource {
+				selected = i
+				break
+			}
+		}
+	}
+
+	return mirrorPickerModel{
+		availableMonitors: availableMonitors,
+		selected:          selected,
+		currentMonitor:    currentMonitor,
+		currentSource:     currentSource,
+	}
+}
+
+type mirrorSelectedMsg struct {
+	source string // Empty string means disable mirroring
+}
+
+type mirrorCancelledMsg struct{}
+
+func (m mirrorPickerModel) Init() tea.Cmd {
+	return nil
+}
+
+func (m mirrorPickerModel) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
+	switch msg := msg.(type) {
+	case tea.KeyMsg:
+		switch msg.String() {
+		case "up", "k":
+			if m.selected > 0 {
+				m.selected--
+			}
+		case "down", "j":
+			if m.selected < len(m.availableMonitors)-1 {
+				m.selected++
+			}
+		case "enter":
+			source := ""
+			if m.selected > 0 { // Skip "None" option
+				source = m.availableMonitors[m.selected]
+			}
+			return m, func() tea.Msg {
+				return mirrorSelectedMsg{source: source}
+			}
+		case "esc", "q":
+			return m, func() tea.Msg {
+				return mirrorCancelledMsg{}
+			}
+		}
+	}
+
+	return m, nil
+}
+
+func (m mirrorPickerModel) View() string {
+	var b strings.Builder
+
+	title := fmt.Sprintf("Mirror Configuration for %s", m.currentMonitor)
+	b.WriteString(lipgloss.NewStyle().Bold(true).Foreground(lipgloss.Color("12")).Render(title))
+	b.WriteString("\n\n")
+
+	if len(m.availableMonitors) == 1 {
+		b.WriteString("No monitors available for mirroring.\n")
+		b.WriteString("(Only active, non-mirrored monitors can be mirror sources)\n\n")
+
+		warningStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("208"))
+		b.WriteString(warningStyle.Render("Note: Circular mirroring is not allowed"))
+		b.WriteString("\n\n")
+
+		b.WriteString("Press ESC to cancel")
+		return b.String()
+	}
+
+	b.WriteString("Select a monitor to mirror from:\n\n")
+
+	for i, monitor := range m.availableMonitors {
+		prefix := "  "
+		suffix := ""
+
+		if i == m.selected {
+			prefix = "> "
+			suffix = " <"
+		}
+
+		style := lipgloss.NewStyle()
+		if i == m.selected {
+			style = style.Bold(true).Foreground(lipgloss.Color("214"))
+		} else if monitor == "None" {
+			style = style.Foreground(lipgloss.Color("244"))
+		} else {
+			style = style.Foreground(lipgloss.Color("42"))
+		}
+
+		line := prefix + monitor + suffix
+		switch monitor {
+		case "None":
+			line += " (Disable mirroring)"
+		case m.currentSource:
+			line += " (current)"
+		}
+
+		b.WriteString(style.Render(line))
+		b.WriteString("\n")
+	}
+
+	b.WriteString("\n")
+
+	// Add warning about resolution mismatches if applicable
+	if len(m.availableMonitors) > 1 {
+		warningStyle := lipgloss.NewStyle().Foreground(lipgloss.Color("208"))
+		b.WriteString(warningStyle.Render("⚠  Mirroring monitors with different resolutions may cause stretching"))
+		b.WriteString("\n")
+	}
+
+	b.WriteString("↑/↓: Navigate  Enter: Select  ESC: Cancel")
+
+	return b.String()
+}

--- a/mirror_test.go
+++ b/mirror_test.go
@@ -1,0 +1,118 @@
+package main
+
+import (
+	"testing"
+)
+
+func TestWouldCreateCircularMirror(t *testing.T) {
+	tests := []struct {
+		name             string
+		currentMonitor   string
+		sourceMonitor    string
+		allMonitors      []Monitor
+		expectedCircular bool
+	}{
+		{
+			name:           "No circular mirror - simple case",
+			currentMonitor: "HDMI-A-1",
+			sourceMonitor:  "eDP-1",
+			allMonitors: []Monitor{
+				{Name: "HDMI-A-1", Active: true},
+				{Name: "eDP-1", Active: true},
+			},
+			expectedCircular: false,
+		},
+		{
+			name:           "Direct circular mirror",
+			currentMonitor: "HDMI-A-1",
+			sourceMonitor:  "eDP-1",
+			allMonitors: []Monitor{
+				{Name: "HDMI-A-1", Active: true},
+				{Name: "eDP-1", Active: true, IsMirrored: true, MirrorSource: "HDMI-A-1"},
+			},
+			expectedCircular: true,
+		},
+		{
+			name:           "Indirect circular mirror (3 monitors)",
+			currentMonitor: "HDMI-A-1",
+			sourceMonitor:  "eDP-1",
+			allMonitors: []Monitor{
+				{Name: "HDMI-A-1", Active: true},
+				{Name: "eDP-1", Active: true, IsMirrored: true, MirrorSource: "DP-1"},
+				{Name: "DP-1", Active: true, IsMirrored: true, MirrorSource: "HDMI-A-1"},
+			},
+			expectedCircular: true,
+		},
+		{
+			name:           "No circular mirror - chain but not circular",
+			currentMonitor: "HDMI-A-1",
+			sourceMonitor:  "eDP-1",
+			allMonitors: []Monitor{
+				{Name: "HDMI-A-1", Active: true},
+				{Name: "eDP-1", Active: true, IsMirrored: true, MirrorSource: "DP-1"},
+				{Name: "DP-1", Active: true},
+			},
+			expectedCircular: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := wouldCreateCircularMirror(tt.currentMonitor, tt.sourceMonitor, tt.allMonitors)
+			if result != tt.expectedCircular {
+				t.Errorf("wouldCreateCircularMirror() = %v, want %v", result, tt.expectedCircular)
+			}
+		})
+	}
+}
+
+func TestValidateMirrorConfiguration(t *testing.T) {
+	tests := []struct {
+		name             string
+		monitors         []Monitor
+		expectedWarnings int
+	}{
+		{
+			name: "No warnings - valid configuration",
+			monitors: []Monitor{
+				{Name: "HDMI-A-1", Active: true, PxW: 1920, PxH: 1080},
+				{Name: "eDP-1", Active: true, PxW: 1920, PxH: 1080, IsMirrored: true, MirrorSource: "HDMI-A-1"},
+			},
+			expectedWarnings: 0,
+		},
+		{
+			name: "Resolution mismatch warning",
+			monitors: []Monitor{
+				{Name: "HDMI-A-1", Active: true, PxW: 1920, PxH: 1080},
+				{Name: "eDP-1", Active: true, PxW: 3840, PxH: 2160, IsMirrored: true, MirrorSource: "HDMI-A-1"},
+			},
+			expectedWarnings: 1,
+		},
+		{
+			name: "Disabled source monitor warning",
+			monitors: []Monitor{
+				{Name: "HDMI-A-1", Active: false, PxW: 1920, PxH: 1080},
+				{Name: "eDP-1", Active: true, PxW: 1920, PxH: 1080, IsMirrored: true, MirrorSource: "HDMI-A-1"},
+			},
+			expectedWarnings: 1,
+		},
+		{
+			name: "Multiple warnings",
+			monitors: []Monitor{
+				{Name: "HDMI-A-1", Active: false, PxW: 1920, PxH: 1080},
+				{Name: "eDP-1", Active: true, PxW: 3840, PxH: 2160, IsMirrored: true, MirrorSource: "HDMI-A-1"},
+			},
+			expectedWarnings: 2,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			warnings := validateMirrorConfiguration(tt.monitors)
+			if len(warnings) != tt.expectedWarnings {
+				t.Errorf("validateMirrorConfiguration() returned %d warnings, want %d. Warnings: %v",
+					len(warnings), tt.expectedWarnings, warnings)
+			}
+		})
+	}
+}

--- a/models.go
+++ b/models.go
@@ -30,6 +30,11 @@ type Monitor struct {
 	VRR           int     // 0=off, 1=on, 2=fullscreen-only
 	Transform     int     // 0-7 for rotation/flip
 
+	// Mirror settings
+	IsMirrored    bool     // Whether this monitor is mirroring another
+	MirrorSource  string   // Name of monitor being mirrored (empty if not mirroring)
+	MirrorTargets []string // Names of monitors mirroring this one
+
 	Dragging bool
 	DragOffX int32
 	DragOffY int32
@@ -79,6 +84,8 @@ type model struct {
 	ScalePicker          scalePickerModel
 	ShowModePicker       bool
 	ModePicker           modePickerModel
+	ShowMirrorPicker     bool
+	MirrorPicker         mirrorPickerModel
 	ShowProfileInput     bool
 	ProfileInput         profileInputModel
 	ShowHelp             bool


### PR DESCRIPTION
- Add comprehensive monitor mirroring functionality with M key
- Implement mirror relationship detection from Hyprland
- Add visual indicators and dotted connection lines for mirrored monitors
- Create mirror picker dialog with circular dependency prevention
- Add validation warnings for resolution mismatches
- Generate correct Hyprland mirror syntax in config files
- Integrate mirror settings with profile system
- Add comprehensive test coverage for mirror validation
- Upgrade Go version from 1.24.6 to 1.25.1 across all workflows
- Update dependencies for Go 1.25.1 compatibility

Deals with #36 