### PR TITLE
FIX: transform wasn't loaded

### DIFF
--- a/hyprland.go
+++ b/hyprland.go
@@ -160,6 +160,9 @@ func readMonitors() ([]Monitor, error) {
 			EDIDName: hm.Description,
 			Modes:    modes,
 
+			// Advanced display settings
+			Transform: int(hm.Transform),
+
 			// Mirror settings
 			IsMirrored: hm.MirrorOf != "" && hm.MirrorOf != "none",
 			MirrorSource: func() string {


### PR DESCRIPTION
Thank you for writing this wonderful software :)

I have a rotated monitor. Configuring this was my reason to use hyprmon. Configuring my setup was easy. Hyprmon wrote the conf file correctly. But opening hypermon again showed the rotated monitor without rotation. Everytime i want to make changes, i have to rotate the monitor again.

Luckily, it was easy to find the location in the code where i could add the transform. Nice code structure btw.
Actually, all "Advanced display settings" are not loaded, but i just added the transform. The other fields seem to be harder to add. Otherwise i would have added them too.