### PR TITLE
fix: write config and reload after applying a profile

### DIFF
--- a/profiles.go
+++ b/profiles.go
@@ -228,6 +228,14 @@ func applyProfile(name string) error {
 		return fmt.Errorf("failed to apply profile: %w", err)
 	}
 
+	if err := writeConfig(resolved); err != nil {
+		return fmt.Errorf("failed to write config: %w", err)
+	}
+
+	if err := reloadConfig(); err != nil {
+		return fmt.Errorf("failed to reload config: %w", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Fixes a bug where applying a profile from the profile menu did not persist changes to `hyprland.conf` or trigger a config reload
- `applyProfile()` now calls `writeConfig()` and `reloadConfig()` after successfully applying monitors via hyprctl
- This ensures wallpaper managers, waybar, and other tools that depend on config reload are properly notified

Fixes #69

## Test plan

- [ ] Open hyprmon, press "O", select a saved profile
- [ ] Verify monitors move to correct positions
- [ ] Verify wallpaper and waybar render on the correct screens
- [ ] Verify `~/.config/hypr/hyprland.conf` contains the updated monitor lines
- [ ] Verify `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)