### PR TITLE
feat: migrate workspaces on profile apply + clamshell mode docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,19 @@ bind = $mainMod, F3, exec, hyprmon --profile laptop
 bind = $mainMod, F4, exec, hyprmon profiles
 ```
 
+### Laptop Lid / Clamshell Mode
+
+HyprMon profiles can be used for laptop clamshell mode by combining them with Hyprland's lid switch bindings. Create two profiles — one for docked use (laptop display off, external monitor only) and one for laptop-only use — then add these lines to your `hyprland.conf`:
+
+```
+bindl = , switch:on:Lid Switch, exec, hyprmon --profile docked
+bindl = , switch:off:Lid Switch, exec, hyprmon --profile laptop
+```
+
+When the lid closes, HyprMon will apply the "docked" profile, disable the laptop display, save the configuration, and automatically migrate workspaces to the external monitor. When the lid opens, the "laptop" profile restores the internal display.
+
+> **Note**: You may need to set `HandleLidSwitch=ignore` in `/etc/systemd/logind.conf` to prevent systemd from suspending the laptop when the lid closes.
+
 ## Configuration
 
 HyprMon reads and writes to your Hyprland configuration file. The location is determined in this order:

--- a/profiles.go
+++ b/profiles.go
@@ -224,8 +224,17 @@ func applyProfile(name string) error {
 
 	saveRollback(resolved)
 
+	// Get current monitor names before applying changes
+	previousNames, _ := getCurrentMonitorNames()
+
 	if err := applyMonitors(resolved); err != nil {
 		return fmt.Errorf("failed to apply profile: %w", err)
+	}
+
+	// Get monitor names after applying and migrate orphaned workspaces
+	currentNames, _ := getCurrentMonitorNames()
+	if err := migrateOrphanedWorkspaces(previousNames, currentNames); err != nil {
+		fmt.Printf("Warning: Failed to migrate workspaces: %v\n", err)
 	}
 
 	if err := writeConfig(resolved); err != nil {


### PR DESCRIPTION
## Summary

- When applying a profile that disables monitors, workspaces are now automatically migrated to remaining active monitors (matching the existing Apply behavior in the main UI)
- Added documentation for using hyprmon profiles with Hyprland's `bindl` lid switch bindings for laptop clamshell mode

Relates to #54

## Test plan

- [ ] Create a profile that disables one monitor
- [ ] Apply profile via `hyprmon --profile <name>` — verify workspaces migrate off the disabled monitor
- [ ] Apply profile via the profile menu (press O) — verify same behavior
- [ ] Verify `make test` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)