### PR TITLE
[codex] add Hyprland Lua config writer

### DIFF
--- a/README.md
+++ b/README.md
@@ -234,30 +234,40 @@ To opt in per monitor:
 
 1. Select the monitor and press `c` (or `d`) to open advanced settings.
 2. Toggle **Write as desc:** to On.
-3. Save your configuration (`S`) to write `hyprland.conf` in the new format.
+3. Save your configuration (`S`) to persist the monitor using `desc:` in whichever Hyprland config format is active.
 
 The toggle is unavailable when the monitor has no EDID description, when two or more connected monitors share the same description (typically identical monitors without a serial number), or when the description contains characters Hyprland cannot parse. The preference persists across sessions in `~/.config/hyprmon/settings.json` and is also stored inside any profile you save that includes the monitor.
 
-Live application via `hyprctl` continues to use connector names — the `desc:` format applies only to the persisted `hyprland.conf`.
+Live application via `hyprctl` continues to use connector names — the `desc:` format applies only to persisted config files.
 
 ## Configuration
 
 HyprMon reads and writes to your Hyprland configuration file. The location is determined in this order:
 
-1. `$HYPRLAND_CONFIG` environment variable
-2. `~/.config/hypr/hyprland.conf` (default)
+1. `$HYPRLAND_CONFIG` environment variable. Paths ending in `.lua` use the Lua writer; other paths use the legacy hyprlang writer.
+2. `~/.config/hypr/hyprland.lua` when it exists.
+3. `~/.config/hypr/hyprland.conf` (legacy fallback).
+
+For Lua configs, HyprMon writes monitor rules to `~/.config/hypr/hyprmon.lua` and adds this managed include to `hyprland.lua` if it is not already present:
+
+```lua
+-- hyprmon: managed monitor profile include
+require("hyprmon")
+```
+
+For legacy hyprlang configs, HyprMon keeps the existing behavior and rewrites only the `monitor=` lines in `hyprland.conf`.
 
 ### Backup Files
 
 Before any configuration changes, HyprMon creates a backup:
-- Location: `hyprland.conf.bak.<timestamp>`
+- Location: `<config-file>.bak.<timestamp>`
 - These backups are never automatically deleted
 
 ## How It Works
 
 1. **Reading**: HyprMon uses `hyprctl monitors -j` to read current monitor configuration
 2. **Applying**: Live changes use `hyprctl keyword monitor ...` commands
-3. **Saving**: Updates only the `monitor=` lines in your hyprland.conf
+3. **Saving**: Updates `monitor=` lines in legacy hyprlang config, or updates the managed `hyprmon.lua` sidecar for Lua config
 4. **Rollback**: Maintains previous state for quick reversion
 
 ## Terminal Requirements

--- a/docs/superpowers/plans/2026-05-18-hyprland-lua-config-writer.md
+++ b/docs/superpowers/plans/2026-05-18-hyprland-lua-config-writer.md
@@ -1,0 +1,209 @@
+# Hyprland Lua Config Writer Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add persistence support for Hyprland 0.55+ Lua monitor configuration while preserving the existing hyprlang writer.
+
+**Architecture:** Split config persistence into target detection plus format-specific writers. Existing `monitor=...` generation remains the hyprlang backend; Lua support adds `hl.monitor({...})` rendering and writes monitor rules through a HyprMon-managed `hyprmon.lua` sidecar required by `hyprland.lua`.
+
+**Tech Stack:** Go standard library, existing HyprMon monitor model, existing `go test ./...` suite.
+
+---
+
+### Task 1: Detect Config Target Format
+
+**Files:**
+- Modify: `hyprland.go`
+- Modify: `hyprland_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests covering:
+
+```go
+func TestGetConfigTargetUsesHYPRLANDCONFIGLua(t *testing.T) {
+	t.Setenv("HYPRLAND_CONFIG", "/tmp/hyprland.lua")
+	target, err := getConfigTarget()
+	if err != nil {
+		t.Fatalf("getConfigTarget() error = %v", err)
+	}
+	if target.Path != "/tmp/hyprland.lua" {
+		t.Fatalf("Path = %q, want /tmp/hyprland.lua", target.Path)
+	}
+	if target.Format != configFormatLua {
+		t.Fatalf("Format = %v, want configFormatLua", target.Format)
+	}
+}
+
+func TestGetConfigTargetUsesHYPRLANDCONFIGConf(t *testing.T) {
+	t.Setenv("HYPRLAND_CONFIG", "/tmp/hyprland.conf")
+	target, err := getConfigTarget()
+	if err != nil {
+		t.Fatalf("getConfigTarget() error = %v", err)
+	}
+	if target.Format != configFormatHyprlang {
+		t.Fatalf("Format = %v, want configFormatHyprlang", target.Format)
+	}
+}
+
+func TestGetConfigTargetPrefersDefaultLuaWhenPresent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HYPRLAND_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	hyprDir := filepath.Join(dir, "hypr")
+	if err := os.MkdirAll(hyprDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	luaPath := filepath.Join(hyprDir, "hyprland.lua")
+	if err := os.WriteFile(luaPath, []byte("-- lua"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	target, err := getConfigTarget()
+	if err != nil {
+		t.Fatalf("getConfigTarget() error = %v", err)
+	}
+	if target.Path != luaPath || target.Format != configFormatLua {
+		t.Fatalf("target = %#v, want %q lua", target, luaPath)
+	}
+}
+
+func TestGetConfigTargetFallsBackToDefaultConf(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HYPRLAND_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	target, err := getConfigTarget()
+	if err != nil {
+		t.Fatalf("getConfigTarget() error = %v", err)
+	}
+	want := filepath.Join(dir, "hypr", "hyprland.conf")
+	if target.Path != want || target.Format != configFormatHyprlang {
+		t.Fatalf("target = %#v, want %q hyprlang", target, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `go test ./...`
+
+Expected: compile failure because `getConfigTarget`, `configFormatLua`, and `configFormatHyprlang` do not exist.
+
+- [ ] **Step 3: Implement detection**
+
+Add `configFormat`, `configTarget`, `fileExists`, `getHyprConfigDir`, and `getConfigTarget` to `hyprland.go`. Keep `getConfigPath` as a compatibility wrapper returning only the selected path.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `go test ./...`
+
+Expected: all tests pass.
+
+### Task 2: Render Lua Monitor Rules
+
+**Files:**
+- Modify: `hyprland.go`
+- Modify: `hyprland_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Add tests for active, disabled, mirrored, and advanced Lua monitor rules:
+
+```go
+func TestGenerateLuaMonitorRule(t *testing.T) {
+	m := Monitor{Name: "DP-1", PxW: 2560, PxH: 1440, Hz: 144, X: 0, Y: -200, Scale: 1.25, Active: true}
+	got := generateLuaMonitorRule(m)
+	want := "hl.monitor({ output = \"DP-1\", mode = \"2560x1440@144.00\", position = \"0x-200\", scale = 1.25 })"
+	if got != want {
+		t.Fatalf("generateLuaMonitorRule() = %q, want %q", got, want)
+	}
+}
+
+func TestGenerateLuaMonitorRuleDisabled(t *testing.T) {
+	m := Monitor{Name: "eDP-1", Active: false}
+	got := generateLuaMonitorRule(m)
+	want := "hl.monitor({ output = \"eDP-1\", disabled = true })"
+	if got != want {
+		t.Fatalf("generateLuaMonitorRule() = %q, want %q", got, want)
+	}
+}
+
+func TestGenerateLuaMonitorRuleAdvanced(t *testing.T) {
+	m := Monitor{Name: "DP-1", PxW: 3840, PxH: 2160, Hz: 60, X: 0, Y: 0, Scale: 1, Active: true, BitDepth: 10, ColorMode: "hdr", SDRBrightness: 1.2, SDRSaturation: 0.9, VRR: 1, Transform: 1}
+	got := generateLuaMonitorRule(m)
+	want := "hl.monitor({ output = \"DP-1\", mode = \"3840x2160@60.00\", position = \"0x0\", scale = 1.00, bitdepth = 10, cm = \"hdr\", sdrbrightness = 1.20, sdrsaturation = 0.90, vrr = 1, transform = 1 })"
+	if got != want {
+		t.Fatalf("generateLuaMonitorRule() = %q, want %q", got, want)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `go test ./...`
+
+Expected: compile failure because `generateLuaMonitorRule` does not exist.
+
+- [ ] **Step 3: Implement Lua renderer**
+
+Add `generateLuaMonitorRule`, using `resolveMonitorIdentifier` shared with `generateMonitorLine`. Escape Lua strings with `%q`; validate monitor and mirror names like the existing writer.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `go test ./...`
+
+Expected: all tests pass.
+
+### Task 3: Dispatch Writers and Manage Lua Sidecar
+
+**Files:**
+- Modify: `hyprland.go`
+- Modify: `hyprland_test.go`
+
+- [ ] **Step 1: Write failing tests**
+
+Add temp-file tests that verify:
+- `writeConfig` dispatches to hyprlang when `HYPRLAND_CONFIG` points at `.conf`.
+- `writeConfig` dispatches to Lua when `HYPRLAND_CONFIG` points at `.lua`.
+- Lua mode creates or updates `hyprmon.lua` next to `hyprland.lua`.
+- Lua mode appends exactly one `require("hyprmon")` line to `hyprland.lua`.
+
+- [ ] **Step 2: Run tests to verify failure**
+
+Run: `go test ./...`
+
+Expected: tests fail because `writeConfig` still only edits monitor lines in the selected file.
+
+- [ ] **Step 3: Implement dispatch and Lua sidecar writing**
+
+Rename the existing body to `writeHyprlangConfig(configPath string, monitors []Monitor) error`. Make `writeConfig` call `getConfigTarget` and dispatch. Add `writeLuaConfig(configPath string, monitors []Monitor) error`, which backs up `hyprland.lua`, writes `hyprmon.lua`, and ensures a managed `require("hyprmon")` line exists in `hyprland.lua` without duplicating it.
+
+- [ ] **Step 4: Run tests to verify pass**
+
+Run: `go test ./...`
+
+Expected: all tests pass.
+
+### Task 4: Documentation and Final Verification
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] **Step 1: Update README**
+
+Document that HyprMon now writes either:
+- `hyprland.conf` monitor lines for legacy hyprlang config.
+- `hyprmon.lua` plus `require("hyprmon")` for Lua config.
+
+- [ ] **Step 2: Format and test**
+
+Run:
+
+```bash
+gofmt -w hyprland.go hyprland_test.go
+go test ./...
+git status --short
+```
+
+Expected: tests pass and only planned files are modified.

--- a/hyprland.go
+++ b/hyprland.go
@@ -33,7 +33,22 @@ const (
 	// UI layout constants
 	desktopBorderMargin = 3  // Border (2) + margin (1)
 	desktopFooterHeight = 10 // Height reserved for footer
+
+	hyprmonLuaRequireComment = "-- hyprmon: managed monitor profile include"
+	hyprmonLuaRequireLine    = `require("hyprmon")`
 )
+
+type configFormat int
+
+const (
+	configFormatHyprlang configFormat = iota
+	configFormatLua
+)
+
+type configTarget struct {
+	Path   string
+	Format configFormat
+}
 
 // isValidMonitorName validates that a monitor name is safe to use in commands
 func isValidMonitorName(name string) bool {
@@ -383,26 +398,91 @@ func applyMonitors(monitors []Monitor) error {
 	return nil
 }
 
-func getConfigPath() string {
-	if envPath := os.Getenv("HYPRLAND_CONFIG"); envPath != "" {
-		// Validate that the path is absolute and clean to prevent path traversal
-		cleanPath := filepath.Clean(envPath)
-		if !filepath.IsAbs(cleanPath) {
-			return ""
+func cleanAbsoluteConfigPath(path string) (string, error) {
+	cleanPath := filepath.Clean(path)
+	if !filepath.IsAbs(cleanPath) {
+		return "", fmt.Errorf("config path must be absolute: %s", path)
+	}
+	if strings.Contains(path, "..") {
+		return "", fmt.Errorf("config path must not contain '..': %s", path)
+	}
+	return cleanPath, nil
+}
+
+func configFormatForPath(path string) configFormat {
+	if strings.EqualFold(filepath.Ext(path), ".lua") {
+		return configFormatLua
+	}
+	return configFormatHyprlang
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func getHyprConfigDir() (string, error) {
+	if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
+		cleanPath := filepath.Clean(xdgConfigHome)
+		if filepath.IsAbs(cleanPath) {
+			return filepath.Join(cleanPath, "hypr"), nil
 		}
-		// Ensure the path doesn't contain directory traversal attempts
-		if strings.Contains(envPath, "..") {
-			return ""
-		}
-		return cleanPath
 	}
 
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return ""
+		return "", fmt.Errorf("could not determine home directory: %w", err)
+	}
+	return filepath.Join(home, ".config", "hypr"), nil
+}
+
+func getConfigTarget() (configTarget, error) {
+	if envPath := os.Getenv("HYPRLAND_CONFIG"); envPath != "" {
+		cleanPath, err := cleanAbsoluteConfigPath(envPath)
+		if err != nil {
+			return configTarget{}, err
+		}
+		return configTarget{
+			Path:   cleanPath,
+			Format: configFormatForPath(cleanPath),
+		}, nil
 	}
 
-	return filepath.Join(home, ".config", "hypr", "hyprland.conf")
+	hyprDir, err := getHyprConfigDir()
+	if err != nil {
+		return configTarget{}, err
+	}
+
+	luaPath := filepath.Join(hyprDir, "hyprland.lua")
+	if fileExists(luaPath) {
+		return configTarget{
+			Path:   luaPath,
+			Format: configFormatLua,
+		}, nil
+	}
+
+	return configTarget{
+		Path:   filepath.Join(hyprDir, "hyprland.conf"),
+		Format: configFormatHyprlang,
+	}, nil
+}
+
+func getConfigPath() string {
+	target, err := getConfigTarget()
+	if err != nil {
+		return ""
+	}
+	return target.Path
+}
+
+func resolveMonitorIdentifier(m Monitor) string {
+	identifier := m.Name
+	if m.UseDescFormat && canUseDescFormat(m) {
+		if desc := sanitizeDesc(m.EDIDName); desc != "" {
+			identifier = "desc:" + desc
+		}
+	}
+	return identifier
 }
 
 // generateMonitorLine creates the monitor configuration line for a monitor
@@ -414,12 +494,7 @@ func generateMonitorLine(m Monitor) string {
 
 	// Resolve identifier: desc:<description> when the user opted in and the
 	// description is unambiguous and safe; otherwise the connector name.
-	identifier := m.Name
-	if m.UseDescFormat && canUseDescFormat(m) {
-		if desc := sanitizeDesc(m.EDIDName); desc != "" {
-			identifier = "desc:" + desc
-		}
-	}
+	identifier := resolveMonitorIdentifier(m)
 
 	if !m.Active {
 		return fmt.Sprintf("monitor=%s,disable", identifier)
@@ -468,8 +543,75 @@ func generateMonitorLine(m Monitor) string {
 	return monLine
 }
 
+func luaString(s string) string {
+	return fmt.Sprintf("%q", s)
+}
+
+func generateLuaMonitorRule(m Monitor) string {
+	if !isValidMonitorName(m.Name) {
+		return fmt.Sprintf("-- Invalid monitor name: %s", m.Name)
+	}
+
+	identifier := resolveMonitorIdentifier(m)
+	fields := []string{fmt.Sprintf("output = %s", luaString(identifier))}
+
+	if !m.Active {
+		fields = append(fields, "disabled = true")
+		return fmt.Sprintf("hl.monitor({ %s })", strings.Join(fields, ", "))
+	}
+
+	fields = append(fields,
+		fmt.Sprintf("mode = %s", luaString(fmt.Sprintf("%dx%d@%.2f", m.PxW, m.PxH, m.Hz))),
+		fmt.Sprintf("position = %s", luaString(fmt.Sprintf("%dx%d", m.X, m.Y))),
+		fmt.Sprintf("scale = %.2f", m.Scale),
+	)
+
+	if m.IsMirrored && m.MirrorSource != "" {
+		if !isValidMonitorName(m.MirrorSource) {
+			return fmt.Sprintf("-- Invalid mirror source: %s", m.MirrorSource)
+		}
+		fields = append(fields, fmt.Sprintf("mirror = %s", luaString(m.MirrorSource)))
+	} else {
+		if m.BitDepth == 10 {
+			fields = append(fields, "bitdepth = 10")
+		}
+		if m.ColorMode != "" && m.ColorMode != "srgb" && isValidColorMode(m.ColorMode) {
+			fields = append(fields, fmt.Sprintf("cm = %s", luaString(m.ColorMode)))
+		}
+		if m.ColorMode == "hdr" || m.ColorMode == "hdredid" {
+			if m.SDRBrightness != 0 && m.SDRBrightness != 1.0 {
+				fields = append(fields, fmt.Sprintf("sdrbrightness = %.2f", m.SDRBrightness))
+			}
+			if m.SDRSaturation != 0 && m.SDRSaturation != 1.0 {
+				fields = append(fields, fmt.Sprintf("sdrsaturation = %.2f", m.SDRSaturation))
+			}
+		}
+		if m.VRR > 0 {
+			fields = append(fields, fmt.Sprintf("vrr = %d", m.VRR))
+		}
+		if m.Transform > 0 {
+			fields = append(fields, fmt.Sprintf("transform = %d", m.Transform))
+		}
+	}
+
+	return fmt.Sprintf("hl.monitor({ %s })", strings.Join(fields, ", "))
+}
+
 func writeConfig(monitors []Monitor) error {
-	configPath := getConfigPath()
+	target, err := getConfigTarget()
+	if err != nil {
+		return fmt.Errorf("could not determine config path: %w", err)
+	}
+
+	switch target.Format {
+	case configFormatLua:
+		return writeLuaConfig(target.Path, monitors)
+	default:
+		return writeHyprlangConfig(target.Path, monitors)
+	}
+}
+
+func writeHyprlangConfig(configPath string, monitors []Monitor) error {
 	if configPath == "" {
 		return fmt.Errorf("could not determine config path")
 	}
@@ -541,6 +683,83 @@ func writeConfig(monitors []Monitor) error {
 	// Ensure data is written to disk
 	if err = file.Sync(); err != nil {
 		return fmt.Errorf("failed to sync config: %w", err)
+	}
+
+	return nil
+}
+
+func generateLuaMonitorConfig(monitors []Monitor) string {
+	lines := []string{
+		"-- Generated by HyprMon. Manual changes may be overwritten.",
+		"",
+	}
+	for _, m := range monitors {
+		lines = append(lines, generateLuaMonitorRule(m))
+	}
+	return strings.Join(lines, "\n") + "\n"
+}
+
+func hasHyprmonLuaRequire(input string) bool {
+	for _, line := range strings.Split(input, "\n") {
+		if strings.TrimSpace(line) == hyprmonLuaRequireLine {
+			return true
+		}
+	}
+	return false
+}
+
+func ensureHyprmonLuaRequire(input string) string {
+	if hasHyprmonLuaRequire(input) {
+		return input
+	}
+
+	if strings.TrimSpace(input) == "" {
+		return hyprmonLuaRequireComment + "\n" + hyprmonLuaRequireLine + "\n"
+	}
+
+	var b strings.Builder
+	b.WriteString(input)
+	if !strings.HasSuffix(input, "\n") {
+		b.WriteString("\n")
+	}
+	b.WriteString("\n")
+	b.WriteString(hyprmonLuaRequireComment)
+	b.WriteString("\n")
+	b.WriteString(hyprmonLuaRequireLine)
+	b.WriteString("\n")
+	return b.String()
+}
+
+func writeLuaConfig(configPath string, monitors []Monitor) error {
+	if configPath == "" {
+		return fmt.Errorf("could not determine config path")
+	}
+
+	configDir := filepath.Dir(configPath)
+	if err := os.MkdirAll(configDir, profileDirMode); err != nil {
+		return fmt.Errorf("failed to ensure lua config directory: %w", err)
+	}
+
+	input, err := os.ReadFile(configPath)
+	if err != nil && !os.IsNotExist(err) {
+		return fmt.Errorf("failed to read lua config: %w", err)
+	}
+
+	if err == nil {
+		backupPath := fmt.Sprintf("%s.bak.%d", configPath, time.Now().Unix())
+		if err := os.WriteFile(backupPath, input, backupFileMode); err != nil {
+			return fmt.Errorf("failed to create backup: %w", err)
+		}
+	}
+
+	sidecarPath := filepath.Join(configDir, "hyprmon.lua")
+	if err := os.WriteFile(sidecarPath, []byte(generateLuaMonitorConfig(monitors)), configFileMode); err != nil {
+		return fmt.Errorf("failed to write lua monitor config: %w", err)
+	}
+
+	mainConfig := ensureHyprmonLuaRequire(string(input))
+	if err := os.WriteFile(configPath, []byte(mainConfig), configFileMode); err != nil {
+		return fmt.Errorf("failed to write lua config include: %w", err)
 	}
 
 	return nil

--- a/hyprland.go
+++ b/hyprland.go
@@ -467,14 +467,6 @@ func getConfigTarget() (configTarget, error) {
 	}, nil
 }
 
-func getConfigPath() string {
-	target, err := getConfigTarget()
-	if err != nil {
-		return ""
-	}
-	return target.Path
-}
-
 func resolveMonitorIdentifier(m Monitor) string {
 	identifier := m.Name
 	if m.UseDescFormat && canUseDescFormat(m) {

--- a/hyprland_test.go
+++ b/hyprland_test.go
@@ -1,6 +1,11 @@
 package main
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
 
 func TestSanitizeDesc(t *testing.T) {
 	tests := []struct {
@@ -88,6 +93,87 @@ func TestCanUseDescFormat(t *testing.T) {
 				t.Errorf("canUseDescFormat() = %v, want %v", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestGetConfigTargetUsesHYPRLANDCONFIGLua(t *testing.T) {
+	t.Setenv("HYPRLAND_CONFIG", "/tmp/hyprland.lua")
+
+	target, err := getConfigTarget()
+	if err != nil {
+		t.Fatalf("getConfigTarget() error = %v", err)
+	}
+	if target.Path != "/tmp/hyprland.lua" {
+		t.Fatalf("Path = %q, want /tmp/hyprland.lua", target.Path)
+	}
+	if target.Format != configFormatLua {
+		t.Fatalf("Format = %v, want configFormatLua", target.Format)
+	}
+}
+
+func TestGetConfigTargetUsesHYPRLANDCONFIGConf(t *testing.T) {
+	t.Setenv("HYPRLAND_CONFIG", "/tmp/hyprland.conf")
+
+	target, err := getConfigTarget()
+	if err != nil {
+		t.Fatalf("getConfigTarget() error = %v", err)
+	}
+	if target.Path != "/tmp/hyprland.conf" {
+		t.Fatalf("Path = %q, want /tmp/hyprland.conf", target.Path)
+	}
+	if target.Format != configFormatHyprlang {
+		t.Fatalf("Format = %v, want configFormatHyprlang", target.Format)
+	}
+}
+
+func TestGetConfigTargetRejectsUnsafeHYPRLANDCONFIG(t *testing.T) {
+	t.Setenv("HYPRLAND_CONFIG", "relative/hyprland.lua")
+
+	if _, err := getConfigTarget(); err == nil {
+		t.Fatalf("getConfigTarget() error = nil, want error")
+	}
+}
+
+func TestGetConfigTargetPrefersDefaultLuaWhenPresent(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HYPRLAND_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", dir)
+	hyprDir := filepath.Join(dir, "hypr")
+	if err := os.MkdirAll(hyprDir, 0700); err != nil {
+		t.Fatal(err)
+	}
+	luaPath := filepath.Join(hyprDir, "hyprland.lua")
+	if err := os.WriteFile(luaPath, []byte("-- lua"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	target, err := getConfigTarget()
+	if err != nil {
+		t.Fatalf("getConfigTarget() error = %v", err)
+	}
+	if target.Path != luaPath {
+		t.Fatalf("Path = %q, want %q", target.Path, luaPath)
+	}
+	if target.Format != configFormatLua {
+		t.Fatalf("Format = %v, want configFormatLua", target.Format)
+	}
+}
+
+func TestGetConfigTargetFallsBackToDefaultConf(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HYPRLAND_CONFIG", "")
+	t.Setenv("XDG_CONFIG_HOME", dir)
+
+	target, err := getConfigTarget()
+	if err != nil {
+		t.Fatalf("getConfigTarget() error = %v", err)
+	}
+	want := filepath.Join(dir, "hypr", "hyprland.conf")
+	if target.Path != want {
+		t.Fatalf("Path = %q, want %q", target.Path, want)
+	}
+	if target.Format != configFormatHyprlang {
+		t.Fatalf("Format = %v, want configFormatHyprlang", target.Format)
 	}
 }
 
@@ -194,6 +280,99 @@ func TestGenerateMonitorLineDescFormat(t *testing.T) {
 	})
 }
 
+func TestGenerateLuaMonitorRule(t *testing.T) {
+	m := Monitor{
+		Name:   "DP-1",
+		PxW:    2560,
+		PxH:    1440,
+		Hz:     144,
+		X:      0,
+		Y:      -200,
+		Scale:  1.25,
+		Active: true,
+	}
+
+	got := generateLuaMonitorRule(m)
+	want := `hl.monitor({ output = "DP-1", mode = "2560x1440@144.00", position = "0x-200", scale = 1.25 })`
+	if got != want {
+		t.Fatalf("generateLuaMonitorRule() = %q, want %q", got, want)
+	}
+}
+
+func TestGenerateLuaMonitorRuleDisabled(t *testing.T) {
+	m := Monitor{Name: "eDP-1", Active: false}
+
+	got := generateLuaMonitorRule(m)
+	want := `hl.monitor({ output = "eDP-1", disabled = true })`
+	if got != want {
+		t.Fatalf("generateLuaMonitorRule() = %q, want %q", got, want)
+	}
+}
+
+func TestGenerateLuaMonitorRuleUsesDescFormat(t *testing.T) {
+	m := Monitor{
+		Name:          "DP-9",
+		HardwareID:    "Dell Inc./DELL U3419W/5HJB6T2",
+		EDIDName:      "Dell Inc. DELL U3419W 5HJB6T2",
+		UseDescFormat: true,
+		PxW:           3440,
+		PxH:           1440,
+		Hz:            60,
+		Scale:         1,
+		Active:        true,
+	}
+
+	got := generateLuaMonitorRule(m)
+	want := `hl.monitor({ output = "desc:Dell Inc. DELL U3419W 5HJB6T2", mode = "3440x1440@60.00", position = "0x0", scale = 1.00 })`
+	if got != want {
+		t.Fatalf("generateLuaMonitorRule() = %q, want %q", got, want)
+	}
+}
+
+func TestGenerateLuaMonitorRuleMirrored(t *testing.T) {
+	m := Monitor{
+		Name:         "DP-2",
+		PxW:          1920,
+		PxH:          1080,
+		Hz:           60,
+		Scale:        1,
+		Active:       true,
+		IsMirrored:   true,
+		MirrorSource: "DP-1",
+	}
+
+	got := generateLuaMonitorRule(m)
+	want := `hl.monitor({ output = "DP-2", mode = "1920x1080@60.00", position = "0x0", scale = 1.00, mirror = "DP-1" })`
+	if got != want {
+		t.Fatalf("generateLuaMonitorRule() = %q, want %q", got, want)
+	}
+}
+
+func TestGenerateLuaMonitorRuleAdvanced(t *testing.T) {
+	m := Monitor{
+		Name:          "DP-1",
+		PxW:           3840,
+		PxH:           2160,
+		Hz:            60,
+		X:             0,
+		Y:             0,
+		Scale:         1,
+		Active:        true,
+		BitDepth:      10,
+		ColorMode:     "hdr",
+		SDRBrightness: 1.2,
+		SDRSaturation: 0.9,
+		VRR:           1,
+		Transform:     1,
+	}
+
+	got := generateLuaMonitorRule(m)
+	want := `hl.monitor({ output = "DP-1", mode = "3840x2160@60.00", position = "0x0", scale = 1.00, bitdepth = 10, cm = "hdr", sdrbrightness = 1.20, sdrsaturation = 0.90, vrr = 1, transform = 1 })`
+	if got != want {
+		t.Fatalf("generateLuaMonitorRule() = %q, want %q", got, want)
+	}
+}
+
 func TestApplyMonitorPrefs(t *testing.T) {
 	monitors := []Monitor{
 		{Name: "DP-9", HardwareID: "Dell Inc./DELL U3419W/5HJB6T2"},
@@ -215,5 +394,147 @@ func TestApplyMonitorPrefs(t *testing.T) {
 	}
 	if monitors[2].UseDescFormat {
 		t.Errorf("monitors[2] (empty hwid) should be unchanged (false)")
+	}
+}
+
+func TestWriteConfigUsesHyprlangWriterForConf(t *testing.T) {
+	dir := t.TempDir()
+	confPath := filepath.Join(dir, "hyprland.conf")
+	input := strings.Join([]string{
+		"# before",
+		"monitor=OLD,preferred,auto,1",
+		"# after",
+	}, "\n")
+	if err := os.WriteFile(confPath, []byte(input), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HYPRLAND_CONFIG", confPath)
+
+	monitors := []Monitor{{
+		Name:   "DP-1",
+		PxW:    1920,
+		PxH:    1080,
+		Hz:     60,
+		Scale:  1,
+		Active: true,
+	}}
+
+	if err := writeConfig(monitors); err != nil {
+		t.Fatalf("writeConfig() error = %v", err)
+	}
+
+	data, err := os.ReadFile(confPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got := string(data)
+	if !strings.Contains(got, "monitor=DP-1,1920x1080@60.00,0x0,1.00") {
+		t.Fatalf("hyprland.conf did not contain generated monitor line:\n%s", got)
+	}
+	if fileExists(filepath.Join(dir, "hyprmon.lua")) {
+		t.Fatalf("hyprmon.lua should not be created for hyprland.conf writer")
+	}
+}
+
+func TestWriteConfigUsesLuaSidecarForLua(t *testing.T) {
+	dir := t.TempDir()
+	luaPath := filepath.Join(dir, "hyprland.lua")
+	if err := os.WriteFile(luaPath, []byte("-- user config\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HYPRLAND_CONFIG", luaPath)
+
+	monitors := []Monitor{{
+		Name:   "DP-1",
+		PxW:    2560,
+		PxH:    1440,
+		Hz:     144,
+		X:      0,
+		Y:      -200,
+		Scale:  1.25,
+		Active: true,
+	}}
+
+	if err := writeConfig(monitors); err != nil {
+		t.Fatalf("writeConfig() error = %v", err)
+	}
+
+	mainData, err := os.ReadFile(luaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mainConfig := string(mainData)
+	if !strings.Contains(mainConfig, "-- user config") {
+		t.Fatalf("hyprland.lua did not preserve existing content:\n%s", mainConfig)
+	}
+	if strings.Count(mainConfig, `require("hyprmon")`) != 1 {
+		t.Fatalf("hyprland.lua should contain exactly one managed require:\n%s", mainConfig)
+	}
+
+	sidecarPath := filepath.Join(dir, "hyprmon.lua")
+	sidecarData, err := os.ReadFile(sidecarPath)
+	if err != nil {
+		t.Fatalf("failed to read hyprmon.lua: %v", err)
+	}
+	sidecar := string(sidecarData)
+	wantRule := `hl.monitor({ output = "DP-1", mode = "2560x1440@144.00", position = "0x-200", scale = 1.25 })`
+	if !strings.Contains(sidecar, wantRule) {
+		t.Fatalf("hyprmon.lua did not contain generated rule %q:\n%s", wantRule, sidecar)
+	}
+}
+
+func TestWriteLuaConfigDoesNotDuplicateRequire(t *testing.T) {
+	dir := t.TempDir()
+	luaPath := filepath.Join(dir, "hyprland.lua")
+	input := strings.Join([]string{
+		"-- user config",
+		"-- hyprmon: managed monitor profile include",
+		`require("hyprmon")`,
+	}, "\n")
+	if err := os.WriteFile(luaPath, []byte(input), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("HYPRLAND_CONFIG", luaPath)
+
+	monitors := []Monitor{{Name: "eDP-1", Active: false}}
+
+	if err := writeConfig(monitors); err != nil {
+		t.Fatalf("writeConfig() first call error = %v", err)
+	}
+	if err := writeConfig(monitors); err != nil {
+		t.Fatalf("writeConfig() second call error = %v", err)
+	}
+
+	mainData, err := os.ReadFile(luaPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	mainConfig := string(mainData)
+	if strings.Count(mainConfig, `require("hyprmon")`) != 1 {
+		t.Fatalf("hyprland.lua should contain exactly one managed require after repeated writes:\n%s", mainConfig)
+	}
+
+	sidecarData, err := os.ReadFile(filepath.Join(dir, "hyprmon.lua"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(string(sidecarData), `hl.monitor({ output = "eDP-1", disabled = true })`) {
+		t.Fatalf("hyprmon.lua did not contain disabled monitor rule:\n%s", string(sidecarData))
+	}
+}
+
+func TestEnsureHyprmonLuaRequireIgnoresCommentedRequire(t *testing.T) {
+	input := strings.Join([]string{
+		"-- user config",
+		`-- require("hyprmon")`,
+	}, "\n")
+
+	got := ensureHyprmonLuaRequire(input)
+
+	if strings.Count(got, `require("hyprmon")`) != 2 {
+		t.Fatalf("expected commented require plus active managed require:\n%s", got)
+	}
+	if !strings.Contains(got, hyprmonLuaRequireComment+"\n"+hyprmonLuaRequireLine) {
+		t.Fatalf("expected managed require block:\n%s", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Add config target detection that chooses the Lua writer for `.lua` configs and keeps the existing hyprlang writer for `.conf` configs.
- Add Lua monitor rule rendering and a managed `hyprmon.lua` sidecar included from `hyprland.lua`.
- Document the new persistence behavior and add coverage for target detection, Lua rendering, writer dispatch, and include management.

## Context
Refs #78, which reported that Hyprland 0.55.x users with `hyprland.lua` could not persist profiles because HyprMon only rewrote `hyprland.conf` monitor lines.

## Test Plan
- `go test -count=1 ./...`
