### PR TITLE
[codex] Support vertical monitor layouts

### DIFF
--- a/models.go
+++ b/models.go
@@ -125,33 +125,51 @@ type revertMsg struct {
 }
 
 func (m *model) updateWorld() {
+	termW := m.World.TermW
+	termH := m.World.TermH
+
 	if len(m.Monitors) == 0 {
 		m.World = world{
 			Width:  defaultWorldWidth,
 			Height: defaultWorldHeight,
+			TermW:  termW,
+			TermH:  termH,
 			Scale:  defaultWorldScale,
 		}
 		return
 	}
 
-	var maxX, maxY int32
-	for _, mon := range m.Monitors {
-		// Use scaled dimensions for world bounds
-		scaledWidth := int32(float32(mon.PxW) / mon.Scale)
-		scaledHeight := int32(float32(mon.PxH) / mon.Scale)
+	firstWidth, firstHeight := m.getEffectiveDimensions(m.Monitors[0])
+	minX := m.Monitors[0].X
+	minY := m.Monitors[0].Y
+	maxX := m.Monitors[0].X + firstWidth
+	maxY := m.Monitors[0].Y + firstHeight
 
-		if mon.X+scaledWidth > maxX {
-			maxX = mon.X + scaledWidth
+	for _, mon := range m.Monitors[1:] {
+		width, height := m.getEffectiveDimensions(mon)
+
+		if mon.X < minX {
+			minX = mon.X
 		}
-		if mon.Y+scaledHeight > maxY {
-			maxY = mon.Y + scaledHeight
+		if mon.Y < minY {
+			minY = mon.Y
+		}
+		if mon.X+width > maxX {
+			maxX = mon.X + width
+		}
+		if mon.Y+height > maxY {
+			maxY = mon.Y + height
 		}
 	}
 
 	m.World = world{
-		Width:  maxX + worldPaddingPx,
-		Height: maxY + worldPaddingPx,
-		Scale:  defaultWorldScale,
+		Width:   maxX - minX + worldPaddingPx*2,
+		Height:  maxY - minY + worldPaddingPx*2,
+		TermW:   termW,
+		TermH:   termH,
+		Scale:   defaultWorldScale,
+		OffsetX: minX - worldPaddingPx,
+		OffsetY: minY - worldPaddingPx,
 	}
 }
 
@@ -249,6 +267,23 @@ func (m *model) endDrag() {
 	mon := &m.Monitors[m.Selected]
 	mon.Dragging = false
 	m.Guides = nil
+	m.updateWorld()
+}
+
+func (m *model) moveSelected(dx, dy int32) {
+	if m.Selected < 0 || m.Selected >= len(m.Monitors) {
+		return
+	}
+
+	mon := &m.Monitors[m.Selected]
+	mon.X += dx
+	mon.Y += dy
+	if m.Snap != SnapOff {
+		mon.X, mon.Y, m.Guides = m.snapPosition(mon, mon.X, mon.Y)
+	} else {
+		m.Guides = nil
+	}
+	m.updateWorld()
 }
 
 func (m *model) snapPosition(mon *Monitor, x, y int32) (int32, int32, []guide) {

--- a/models_test.go
+++ b/models_test.go
@@ -4,6 +4,8 @@ import (
 	"encoding/json"
 	"strings"
 	"testing"
+
+	tea "github.com/charmbracelet/bubbletea"
 )
 
 func TestGetEffectiveDimensions(t *testing.T) {
@@ -137,6 +139,127 @@ func TestGetEffectiveDimensions(t *testing.T) {
 				t.Errorf("getEffectiveDimensions() height = %d, expected %d", h, tt.expectedH)
 			}
 		})
+	}
+}
+
+func TestUpdateWorldIncludesNegativeCoordinates(t *testing.T) {
+	m := model{
+		World: world{
+			TermW: 120,
+			TermH: 40,
+		},
+		Monitors: []Monitor{
+			{
+				Name:   "Top",
+				X:      640,
+				Y:      -1080,
+				PxW:    2560,
+				PxH:    1080,
+				Scale:  1,
+				Active: true,
+			},
+			{
+				Name:   "LowerLeft",
+				X:      0,
+				Y:      0,
+				PxW:    3840,
+				PxH:    2160,
+				Scale:  1,
+				Active: true,
+			},
+			{
+				Name:   "LowerRight",
+				X:      3840,
+				Y:      0,
+				PxW:    3840,
+				PxH:    2160,
+				Scale:  1,
+				Active: true,
+			},
+		},
+	}
+
+	m.updateWorld()
+
+	if m.World.OffsetX != -worldPaddingPx {
+		t.Fatalf("OffsetX = %d, want %d", m.World.OffsetX, -worldPaddingPx)
+	}
+	if m.World.OffsetY != -1080-worldPaddingPx {
+		t.Fatalf("OffsetY = %d, want %d", m.World.OffsetY, -1080-worldPaddingPx)
+	}
+	if m.World.Width != 7680+worldPaddingPx*2 {
+		t.Fatalf("Width = %d, want %d", m.World.Width, 7680+worldPaddingPx*2)
+	}
+	if m.World.Height != 3240+worldPaddingPx*2 {
+		t.Fatalf("Height = %d, want %d", m.World.Height, 3240+worldPaddingPx*2)
+	}
+
+	topX, topY := m.worldToTerm(640, -1080)
+	if topX <= 0 || topY <= 0 {
+		t.Fatalf("top monitor should render inside padded viewport, got term(%d,%d)", topX, topY)
+	}
+}
+
+func TestUpdateWorldUsesEffectiveDimensionsForBounds(t *testing.T) {
+	m := model{
+		Monitors: []Monitor{
+			{
+				Name:      "Rotated",
+				X:         -100,
+				Y:         -200,
+				PxW:       1920,
+				PxH:       1080,
+				Scale:     1,
+				Transform: 1,
+				Active:    true,
+			},
+		},
+	}
+
+	m.updateWorld()
+
+	if m.World.OffsetX != -100-worldPaddingPx {
+		t.Fatalf("OffsetX = %d, want %d", m.World.OffsetX, -100-worldPaddingPx)
+	}
+	if m.World.OffsetY != -200-worldPaddingPx {
+		t.Fatalf("OffsetY = %d, want %d", m.World.OffsetY, -200-worldPaddingPx)
+	}
+	if m.World.Width != 1080+worldPaddingPx*2 {
+		t.Fatalf("Width = %d, want %d", m.World.Width, 1080+worldPaddingPx*2)
+	}
+	if m.World.Height != 1920+worldPaddingPx*2 {
+		t.Fatalf("Height = %d, want %d", m.World.Height, 1920+worldPaddingPx*2)
+	}
+}
+
+func TestUpdateWorldUsesActualMinimumCoordinates(t *testing.T) {
+	m := model{
+		Monitors: []Monitor{
+			{
+				Name:   "Offset",
+				X:      2000,
+				Y:      1000,
+				PxW:    1920,
+				PxH:    1080,
+				Scale:  1,
+				Active: true,
+			},
+		},
+	}
+
+	m.updateWorld()
+
+	if m.World.OffsetX != 2000-worldPaddingPx {
+		t.Fatalf("OffsetX = %d, want %d", m.World.OffsetX, 2000-worldPaddingPx)
+	}
+	if m.World.OffsetY != 1000-worldPaddingPx {
+		t.Fatalf("OffsetY = %d, want %d", m.World.OffsetY, 1000-worldPaddingPx)
+	}
+	if m.World.Width != 1920+worldPaddingPx*2 {
+		t.Fatalf("Width = %d, want %d", m.World.Width, 1920+worldPaddingPx*2)
+	}
+	if m.World.Height != 1080+worldPaddingPx*2 {
+		t.Fatalf("Height = %d, want %d", m.World.Height, 1080+worldPaddingPx*2)
 	}
 }
 
@@ -404,6 +527,73 @@ func TestSnapPositionWithCenterAlignment(t *testing.T) {
 				t.Errorf("Expected center alignment guides but none were created")
 			}
 		})
+	}
+}
+
+func TestKeyboardMoveUpdatesWorldBounds(t *testing.T) {
+	m := model{
+		GridPx: 32,
+		Snap:   SnapOff,
+		World: world{
+			TermW: 80,
+			TermH: 24,
+		},
+		Selected: 0,
+		Monitors: []Monitor{
+			{
+				Name:   "DP-1",
+				X:      0,
+				Y:      0,
+				PxW:    1920,
+				PxH:    1080,
+				Scale:  1,
+				Active: true,
+			},
+		},
+	}
+	m.updateWorld()
+
+	updated, _ := m.handleKey(tea.KeyMsg{Type: tea.KeyUp})
+	got := updated.(model)
+
+	if got.Monitors[0].Y != -32 {
+		t.Fatalf("monitor Y = %d, want -32", got.Monitors[0].Y)
+	}
+	if got.World.OffsetY != -32-worldPaddingPx {
+		t.Fatalf("OffsetY = %d, want %d", got.World.OffsetY, -32-worldPaddingPx)
+	}
+}
+
+func TestDragEndUpdatesWorldBounds(t *testing.T) {
+	m := model{
+		World: world{
+			TermW: 80,
+			TermH: 24,
+		},
+		Selected: 0,
+		Monitors: []Monitor{
+			{
+				Name:     "DP-1",
+				X:        0,
+				Y:        -64,
+				PxW:      1920,
+				PxH:      1080,
+				Scale:    1,
+				Active:   true,
+				Dragging: true,
+			},
+		},
+	}
+	m.updateWorld()
+	m.Monitors[0].Y = -128
+
+	m.endDrag()
+
+	if m.World.OffsetY != -128-worldPaddingPx {
+		t.Fatalf("OffsetY = %d, want %d", m.World.OffsetY, -128-worldPaddingPx)
+	}
+	if m.Monitors[0].Dragging {
+		t.Fatalf("Dragging = true, want false")
 	}
 }
 

--- a/update.go
+++ b/update.go
@@ -412,100 +412,28 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 		}
 
 	case "up", "k":
-		if m.Selected >= 0 && m.Selected < len(m.Monitors) {
-			step := int32(m.GridPx)
-			mon := &m.Monitors[m.Selected]
-			mon.Y -= step
-			if m.Snap != SnapOff {
-				mon.X, mon.Y, m.Guides = m.snapPosition(mon, mon.X, mon.Y)
-			} else {
-				m.Guides = nil
-			}
-		}
+		m.moveSelected(0, -int32(m.GridPx))
 
 	case "shift+up", "K":
-		if m.Selected >= 0 && m.Selected < len(m.Monitors) {
-			step := int32(m.GridPx) * 10
-			mon := &m.Monitors[m.Selected]
-			mon.Y -= step
-			if m.Snap != SnapOff {
-				mon.X, mon.Y, m.Guides = m.snapPosition(mon, mon.X, mon.Y)
-			} else {
-				m.Guides = nil
-			}
-		}
+		m.moveSelected(0, -int32(m.GridPx)*10)
 
 	case "down", "j":
-		if m.Selected >= 0 && m.Selected < len(m.Monitors) {
-			step := int32(m.GridPx)
-			mon := &m.Monitors[m.Selected]
-			mon.Y += step
-			if m.Snap != SnapOff {
-				mon.X, mon.Y, m.Guides = m.snapPosition(mon, mon.X, mon.Y)
-			} else {
-				m.Guides = nil
-			}
-		}
+		m.moveSelected(0, int32(m.GridPx))
 
 	case "shift+down", "J":
-		if m.Selected >= 0 && m.Selected < len(m.Monitors) {
-			step := int32(m.GridPx) * 10
-			mon := &m.Monitors[m.Selected]
-			mon.Y += step
-			if m.Snap != SnapOff {
-				mon.X, mon.Y, m.Guides = m.snapPosition(mon, mon.X, mon.Y)
-			} else {
-				m.Guides = nil
-			}
-		}
+		m.moveSelected(0, int32(m.GridPx)*10)
 
 	case "left", "h":
-		if m.Selected >= 0 && m.Selected < len(m.Monitors) {
-			step := int32(m.GridPx)
-			mon := &m.Monitors[m.Selected]
-			mon.X -= step
-			if m.Snap != SnapOff {
-				mon.X, mon.Y, m.Guides = m.snapPosition(mon, mon.X, mon.Y)
-			} else {
-				m.Guides = nil
-			}
-		}
+		m.moveSelected(-int32(m.GridPx), 0)
 
 	case "shift+left", "H":
-		if m.Selected >= 0 && m.Selected < len(m.Monitors) {
-			step := int32(m.GridPx) * 10
-			mon := &m.Monitors[m.Selected]
-			mon.X -= step
-			if m.Snap != SnapOff {
-				mon.X, mon.Y, m.Guides = m.snapPosition(mon, mon.X, mon.Y)
-			} else {
-				m.Guides = nil
-			}
-		}
+		m.moveSelected(-int32(m.GridPx)*10, 0)
 
 	case "right", "l":
-		if m.Selected >= 0 && m.Selected < len(m.Monitors) {
-			step := int32(m.GridPx)
-			mon := &m.Monitors[m.Selected]
-			mon.X += step
-			if m.Snap != SnapOff {
-				mon.X, mon.Y, m.Guides = m.snapPosition(mon, mon.X, mon.Y)
-			} else {
-				m.Guides = nil
-			}
-		}
+		m.moveSelected(int32(m.GridPx), 0)
 
 	case "shift+right":
-		if m.Selected >= 0 && m.Selected < len(m.Monitors) {
-			step := int32(m.GridPx) * 10
-			mon := &m.Monitors[m.Selected]
-			mon.X += step
-			if m.Snap != SnapOff {
-				mon.X, mon.Y, m.Guides = m.snapPosition(mon, mon.X, mon.Y)
-			} else {
-				m.Guides = nil
-			}
-		}
+		m.moveSelected(int32(m.GridPx)*10, 0)
 
 	case "g", "G":
 		grids := []int{1, 8, 16, 32, 64}


### PR DESCRIPTION
## Summary

Fixes #77.

This updates the monitor layout world bounds so hyprmon can represent vertical and offset monitor arrangements supported by Hyprland, including negative coordinates and layouts whose minimum coordinate is not `0,0`.

## Changes

- Compute world bounds from the actual min/max monitor extents instead of assuming the desktop starts at origin.
- Use effective dimensions for scaled and rotated monitors when sizing the world.
- Recompute world bounds after keyboard moves and drag completion.
- Add regression tests for negative coordinates, non-zero minimum coordinates, rotated bounds, keyboard movement, and drag completion.

## Validation

- `go test -count=1 ./...`
- `go build ./...`
- `golangci-lint run --timeout=5m`
- `git diff --check`
