### PR TITLE
chore: remove repology badges and cleanup leftover nix .gitignore rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,3 @@
-# Nix
-.direnv
-!.envrc
-result
-
 # Binaries for programs and plugins
 *.exe
 *.exe~

--- a/README.md
+++ b/README.md
@@ -29,15 +29,11 @@ HyprMon is a TUI (Terminal User Interface) tool for configuring monitors on Arch
 
 ### Arch Linux
 
-[![AUR package](https://repology.org/badge/version-for-repo/aur/hyprmon.svg)](https://repology.org/project/hyprmon/versions)
-
 ```bash
 yay -S hyprmon-bin
 ```
 
 ### Nix
-
-[![nixpkgs unstable package](https://repology.org/badge/version-for-repo/nix_unstable/hyprmon.svg)](https://repology.org/project/hyprmon/versions)
 
 #### Try it!
 


### PR DESCRIPTION
There is a different hyprmon package on the AUR which uses a different versioning format so the repology badges are unreliable and appear as if this repo is outdated for AUR when it is not.