### PR TITLE
Reload monitor layout with Ctrl+R

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ hyprmon profiles
 | `S` | Save changes to configuration file |
 | `P` | Save current layout as named profile |
 | `Z` | Revert to previous configuration |
+| `Ctrl+R` | Reload monitors from Hyprland |
 | `Q` or `Ctrl+C` | Quit |
 
 ### Mouse Controls

--- a/models_test.go
+++ b/models_test.go
@@ -530,6 +530,22 @@ func TestSnapPositionWithCenterAlignment(t *testing.T) {
 	}
 }
 
+func TestCtrlRReloadsMonitors(t *testing.T) {
+	m := model{}
+	_, cmd := m.handleKey(tea.KeyMsg{Type: tea.KeyCtrlR})
+	if cmd == nil {
+		t.Fatal("expected reload command for ctrl+r")
+	}
+	msg := cmd()
+	init, ok := msg.(initMsg)
+	if !ok {
+		t.Fatalf("reload command returned %T, want initMsg", msg)
+	}
+	if init.err == nil && init.monitors == nil {
+		t.Fatal("expected monitors or error from reload command")
+	}
+}
+
 func TestKeyboardMoveUpdatesWorldBounds(t *testing.T) {
 	m := model{
 		GridPx: 32,

--- a/update.go
+++ b/update.go
@@ -512,6 +512,10 @@ func (m model) handleKey(msg tea.KeyMsg) (tea.Model, tea.Cmd) {
 	case "z", "Z":
 		return m, revertCmd()
 
+	case "ctrl+r":
+		m.Status = "Reloading monitors..."
+		return m, reloadMonitorsCmd()
+
 	case "o", "O":
 		// Open profiles page
 		m.OpenProfiles = true

--- a/view.go
+++ b/view.go
@@ -158,6 +158,7 @@ func (m model) renderHelp() string {
 		{"O", "Open profiles page"},
 		{"P", "Save as profile"},
 		{"Z", "Revert to previous configuration"},
+		{"Ctrl+R", "Reload monitors from Hyprland"},
 		{"?", "Show this help"},
 		{"Q / Ctrl+C", "Quit"},
 	}


### PR DESCRIPTION
Adds `Ctrl+R` to refresh the monitor layout from Hyprland. Useful when something changed outside the app and you don't want to quit and reopen.