### PR TITLE
 feat: Add JSON output format for listing profiles 

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,13 @@ hyprmon --profile laptop-only
 
 # Interactive profile menu - shows all saved profiles
 hyprmon profiles
+
+# List all available profile names (active profile marked with *)
+hyprmon --list-profiles
+
+# List all profiles formatted as JSON (useful for integration with Waybar, Eww, etc.)
+# Will be formatted as array of objects with "name" and "is_active" keys
+hyprmon --list-profiles --json
 ```
 
 The profile menu allows you to:

--- a/main.go
+++ b/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"encoding/json"
 	"flag"
 	"fmt"
 	"log"
@@ -10,6 +11,11 @@ import (
 	"golang.org/x/term"
 )
 
+type ListProfilesItem struct {
+	Name     string `json:"name"`
+	IsActive bool   `json:"is_active"`
+}
+
 func main() {
 	var profileName string
 	var showProfileMenu bool
@@ -17,6 +23,7 @@ func main() {
 	var showActiveProfile bool
 	var showVersion bool
 	var configPath string
+	var jsonOutput bool
 
 	flag.StringVar(&profileName, "profile", "", "Apply a specific profile")
 	flag.BoolVar(&showProfileMenu, "profiles", false, "Show profile selection menu")
@@ -25,6 +32,7 @@ func main() {
 	flag.BoolVar(&showVersion, "version", false, "Show version information")
 	flag.BoolVar(&showVersion, "v", false, "Show version information (short)")
 	flag.StringVar(&configPath, "cfg", "", "Path to store/read configuration files (default: ~/.config/hyprmon)")
+	flag.BoolVar(&jsonOutput, "json", false, "Format output as JSON (only applicable with --list-profiles)")
 	flag.Parse()
 
 	// Set custom config path if provided
@@ -91,14 +99,35 @@ func main() {
 		// Get the currently active profile
 		activeProfile, _ := getCurrentActiveProfile()
 
-		// Print one profile name per line for easy scripting, with * for active profile
-		for _, profile := range profiles {
-			if profile == activeProfile {
-				fmt.Printf("%s *\n", profile)
-			} else {
-				fmt.Println(profile)
+		if jsonOutput {
+			// Convert profiles to struct
+			var profileList []ListProfilesItem
+			for _, profile := range profiles {
+				profileList = append(profileList, ListProfilesItem{
+					Name:     profile,
+					IsActive: profile == activeProfile,
+				})
+			}
+
+			// Marshal to JSON and print
+			jsonData, err := json.Marshal(profileList)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "Error marshalling profiles to JSON: %v\n", err)
+				os.Exit(1)
+			}
+
+			fmt.Println(string(jsonData))
+		} else {
+			// Print one profile name per line for easy scripting, with * for active profile
+			for _, profile := range profiles {
+				if profile == activeProfile {
+					fmt.Printf("%s *\n", profile)
+				} else {
+					fmt.Println(profile)
+				}
 			}
 		}
+
 		return
 	}
 


### PR DESCRIPTION
 This PR adds support for outputting monitor profiles in JSON format. This is highly useful for integrating  hyprmon  with external scripting tools where structured data is easier to parse than text formatting -- I made this change to make it easier to integrate it into my custom taskbar).

## Key Changes
-  Added  --json  flag: A new boolean flag that formats the output of  --list-profiles  as a JSON array of objects.
- Added  ListProfilesItem  struct: Defined a struct to marshal profile name and its active state (is_active ).
- Documentation: Updated the  README.md  to document both  --list-profiles  and  --json  flags.

## Usage Example
```
# Output format (Standard)
$ hyprmon --list-profiles
home *
work
laptop-only
```
```
# Output format (JSON)
$ hyprmon --list-profiles --json
[{"name": "home", "is_active": true},{"name": "work","is_active": false},{"name": "laptop-only","is_active": false}]
```